### PR TITLE
Add workflow to notify of new upstream commits

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -1,0 +1,36 @@
+name: Check upstream
+
+permissions:
+  contents: read
+  issues: write 
+
+on:
+  schedule:
+    - cron:  '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  check-upstream:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Upstream Commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          previous_issue_number=$(gh issue list --label "upstream change" --json number --jq '.[0].number')
+          if [[ -n $previous_issue_number ]]; then
+            echo Issue already exists
+            exit
+          fi
+          upstream_commit=$(git ls-remote https://yhbt.net/unicorn.git/ HEAD | awk '{ print $1}')
+          if git cat-file -e $upstream_commit^{commit}; then
+            echo No new commits
+            exit
+          fi
+          gh issue create \
+            --title "New upstream commit(s)" \
+            --label "upstream change" \
+            --body "Upstream changed to $upstream_commit"


### PR DESCRIPTION
Creates an issue if upstream advances. I tested this on my fork and it works fine, [here](https://github.com/Earlopain/unicorn-maintained/actions/workflows/check-upstream.yml) are some runs, and [here's](https://github.com/Earlopain/unicorn-maintained/issues/5) an example issue. I can add this to raindrops as well if you see value here.

This should run weekly. It will only create a new issue if one doesn't already exist.